### PR TITLE
Add basic CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    tags:
+      - "*.*.*"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -D warnings
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+      - name: Run cargo fmt (check if all code is rustfmt-ed)
+        run: cargo fmt --all -- --check
+      - name: Run cargo clippy (deny warnings)
+        run: cargo clippy -- -D warnings
+
+  publish-check:
+    name: Publish Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fetch
+      - run: cargo publish --dry-run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ pub trait ProcessExt {
 
     /// Get command after settings the required pipes;
     fn command(&mut self) -> &mut Command {
-        let stdin = self.get_stdin().take().unwrap();
-        let stdout = self.get_stdout().take().unwrap();
-        let stderr = self.get_stderr().take().unwrap();
+        let stdin = self.get_stdin().unwrap();
+        let stdout = self.get_stdout().unwrap();
+        let stderr = self.get_stderr().unwrap();
         let command = self.get_command();
 
         #[cfg(windows)]
@@ -209,7 +209,9 @@ impl Process {
 
     /// Abort the process
     pub fn abort(&self) {
-        self.aborter().map(|k| k.notify_waiters());
+        if let Some(aborter) = self.aborter() {
+            aborter.notify_waiters();
+        }
     }
 }
 


### PR DESCRIPTION
Runs `cargo test` and clippy as well as `cargo publish --dry-run` to make sure that changes pass basic checks.

Note that we don't publish the crate through a workflow yet and only check that the crate could be published without problems at a later stage.